### PR TITLE
Add template experience for rust users

### DIFF
--- a/templates/kinesis-rust/content/Cargo.toml.tmpl
+++ b/templates/kinesis-rust/content/Cargo.toml.tmpl
@@ -1,5 +1,5 @@
 [package]
-name = "{{project-name | kebab_case}}""
+name = "{{project-name | kebab_case}}"
 version = "0.1.0"
 edition = "2021"
 authors = ["{{authors}}"]

--- a/templates/kinesis-rust/content/Cargo.toml.tmpl
+++ b/templates/kinesis-rust/content/Cargo.toml.tmpl
@@ -1,0 +1,18 @@
+[package]
+name = "{{project-name | kebab_case}}""
+version = "0.1.0"
+edition = "2021"
+authors = ["{{authors}}"]
+description = "{{project-description}}"
+
+[lib]
+crate-type = [ "cdylib" ]
+
+[dependencies]
+anyhow = "1"
+bytes = "1"
+http = "0.2"
+spin-sdk = "3.0"
+spin-kinesis-sdk = { git = "https://github.com/ogghead/spin-trigger-kinesis" }
+
+[workspace]

--- a/templates/kinesis-rust/content/spin.toml
+++ b/templates/kinesis-rust/content/spin.toml
@@ -1,19 +1,20 @@
 spin_manifest_version = 2
 
 [application]
-name = "{{project-name | kebab_case}}"
+name = "kinesis-sample"
+authors = ["ogghead <darwin@sprout.org>"]
+description = "Example application for using AWS Kinesis in Fermyon Spin"
 version = "0.1.0"
-authors = ["{{authors}}"]
-description = "{{project-description}}"
 
 [[trigger.kinesis]]
-stream_arn = "{{stream-arn}}"
-batch_size = "{{batch-size}}"
-shard_idle_wait_millis = "{{shard-idle-wait-millis}}"
-detector_poll_millis = "{{detector-poll-millis}}"
-component = "{{project-name | kebab_case}}"
+component = "oggheadtest"
+stream_arn = "arn:aws:kinesis:us-east-1:123456789012:stream/TestStream"
+batch_size = 1000
+shard_idle_wait_millis = 250
+detector_poll_millis = 30000
+shard_iterator_type = "TRIM_HORIZON"
 
-[component.{{project-name | kebab_case}}]
-source = "target/wasm32-wasi/release/{{project-name | snake_case}}.wasm"
-[component.{{project-name | kebab_case}}.build]
+[component.oggheadtest]
+source = "target/wasm32-wasi/release/guest.wasm"
+[component.oggheadtest.build]
 command = "cargo build --target wasm32-wasi --release"

--- a/templates/kinesis-rust/content/spin.toml
+++ b/templates/kinesis-rust/content/spin.toml
@@ -1,0 +1,19 @@
+spin_manifest_version = 2
+
+[application]
+name = "{{project-name | kebab_case}}"
+version = "0.1.0"
+authors = ["{{authors}}"]
+description = "{{project-description}}"
+
+[[trigger.kinesis]]
+stream_arn = "{{stream-arn}}"
+batch_size = "{{batch-size}}"
+shard_idle_wait_millis = "{{shard-idle-wait-millis}}"
+detector_poll_millis = "{{detector-poll-millis}}"
+component = "{{project-name | kebab_case}}"
+
+[component.{{project-name | kebab_case}}]
+source = "target/wasm32-wasi/release/{{project-name | snake_case}}.wasm"
+[component.{{project-name | kebab_case}}.build]
+command = "cargo build --target wasm32-wasi --release"

--- a/templates/kinesis-rust/content/src/lib.rs
+++ b/templates/kinesis-rust/content/src/lib.rs
@@ -7,5 +7,6 @@ async fn handle_batch_records(records: Vec<KinesisRecord>) -> Result<(), Error> 
         let data = String::from_utf8(record.data.inner).unwrap();
         println!("  ... DATA: {:?}", data);
     }
+
     Ok(())
 }

--- a/templates/kinesis-rust/content/src/lib.rs
+++ b/templates/kinesis-rust/content/src/lib.rs
@@ -1,0 +1,11 @@
+use spin_kinesis_sdk::{kinesis_component, Error, KinesisRecord};
+
+#[kinesis_component]
+async fn handle_batch_records(records: Vec<KinesisRecord>) -> Result<(), Error> {
+    for record in records {
+        println!("I GOT A RECORD!  ID: {:?}", record.sequence_number);
+        let data = String::from_utf8(record.data.inner).unwrap();
+        println!("  ... DATA: {:?}", data);
+    }
+    Ok(())
+}

--- a/templates/metadata/spin-template.toml
+++ b/templates/metadata/spin-template.toml
@@ -4,10 +4,9 @@ description = "Kinesis handler/trigger using Rust."
 tags = ["kinesis", "rust"]
 
 [parameters]
-project-description = { type = "string",  prompt = "Description", default = "" }
-kinesis-arn = { type = "string", prompt = "Kinesis ARN", default = "" }
-batch-size = { type = "number", prompt = "Kinesis Batch Size", default = "10" }
-shard-idle-wait-millis
-detector-poll-millis
-shard-iterator-type
-component = 
+project-description = { type = "string", prompt = "Description", default = "" }
+kinesis-arn = { type = "string", prompt = "ARN" }
+batch-size = { type = "string", prompt = "Batch Size", default = "10", pattern = "^(6553[0-5]|655[0-2]\\d|65[0-4]\\d{2}|6[0-4]\\d{3}|[1-5]\\d{4}|[1-9]\\d{0,3}|0)$" }
+shard-idle-wait-millis = { type = "string", prompt = "Batch Size", default = "1000", pattern = "^(6553[0-5]|655[0-2]\\d|65[0-4]\\d{2}|6[0-4]\\d{3}|[1-5]\\d{4}|[1-9]\\d{0,3}|0)$" }
+detector-poll-millis = { type = "string", prompt = "detector poll millis (ms)", default = "30000", pattern = "^(6553[0-5]|655[0-2]\\d|65[0-4]\\d{2}|6[0-4]\\d{3}|[1-5]\\d{4}|[1-9]\\d{0,3}|0)$" }
+shard-iterator-type = { type = "string", prompt = "Shard Iterator Type", pattern = "^(AT_SEQUENCE_NUMBER|AFTER_SEQUENCE_NUMBER|TRIM_HORIZON|LATEST|AT_TIMESTAMP)$" }

--- a/templates/metadata/spin-template.toml
+++ b/templates/metadata/spin-template.toml
@@ -5,4 +5,9 @@ tags = ["kinesis", "rust"]
 
 [parameters]
 project-description = { type = "string",  prompt = "Description", default = "" }
-kinesis_arn = { type = "string", prompt = "Kinesis ARN", default = "" }
+kinesis-arn = { type = "string", prompt = "Kinesis ARN", default = "" }
+batch-size = { type = "number", prompt = "Kinesis Batch Size", default = "10" }
+shard-idle-wait-millis
+detector-poll-millis
+shard-iterator-type
+component = 

--- a/templates/metadata/spin-template.toml
+++ b/templates/metadata/spin-template.toml
@@ -1,0 +1,8 @@
+manifest_version = "1"
+id = "kinesis-rust"
+description = "Kinesis handler/trigger using Rust."
+tags = ["kinesis", "rust"]
+
+[parameters]
+project-description = { type = "string",  prompt = "Description", default = "" }
+kinesis_arn = { type = "string", prompt = "Kinesis ARN", default = "" }


### PR DESCRIPTION
Currently attempts to pull in SDK via GitHub reference ([line 16 in cargo.toml.tmpl](https://github.com/ogghead/spin-trigger-kinesis/compare/main...macolso:add-templates?expand=1#diff-cf9f73c462115495f5606666b16636ebfc7ae53756a8e3582fa9840ea2f0411b)), which is failing on `spin build` 

Need input from @ogghead on debugging or perhaps we can swap this reference out for crate experience instead